### PR TITLE
NPC移動機能の実装

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG of PBL-Game
 
+## v0.18.0 (2025-11-25)
+- NPC_1のみが左右に動くように
+- 移動させるかどうか,速度(speed),距離(max_offset),はdialogues.jsonでNPCごとにパラメータ管理
+- 移動方向はfield.pyのscreen_x,screen_yの部分で管理
+- 現在は左右移動のみ、今後はNPCごとに異なる動きを実装予定
+
 ## v0.17.1 (2025-11-24)
 - バージョン表記方法の変更
 - `src/` 下のファイルにおいて、相対 import を絶対 import に変更

--- a/assets/dialogues/dialogues.json
+++ b/assets/dialogues/dialogues.json
@@ -9,6 +9,11 @@
             "よく来たな！",
             "z キーを押したらクイズが始まるぞ！"
         ],
+        "movement_x": {
+            "enabled": true,
+            "speed": 0.5,
+            "max_offset": 16
+        },
         "quiz": {
             "question": "このゲームは何の言語で書かれている？",
             "choices": [
@@ -28,6 +33,11 @@
         "map_id": "world",
         "lines": [
             "Hello, world!"
-        ]
+        ],
+        "movement_x": {
+            "enabled": false,
+            "speed": 0.5,
+            "max_offset": 16
+        }
     }
 }

--- a/src/core/field.py
+++ b/src/core/field.py
@@ -150,7 +150,25 @@ class Field:
             if not pos or len(pos) < 2:
                 continue
             nx, ny = pos[0], pos[1]
-            screen_x = SCREEN_CENTER_X + (nx - self.app.x) * TILE + ox
+
+            # NPC の左右移動パラメータ初期化
+            movement_config = data.get("movement_x", {})
+            if "offset_x" not in data and movement_config.get("enabled", False):
+                data["offset_x"] = 0
+                data["NPC_speed"] = movement_config.get("speed", 0.5)
+                data["max_offset_x"] = movement_config.get("max_offset", 8)
+
+            # 移動が有効な場合のみ更新
+            if "offset_x" in data:
+                data["offset_x"] += data["NPC_speed"]
+                if abs(data["offset_x"]) > data["max_offset_x"]:
+                    data["NPC_speed"] *= -1
+                screen_x = (
+                    SCREEN_CENTER_X + (nx - self.app.x) * TILE + ox + data["offset_x"]
+                )
+            else:
+                screen_x = SCREEN_CENTER_X + (nx - self.app.x) * TILE + ox
+
             screen_y = SCREEN_CENTER_Y + (ny - self.app.y) * TILE + oy
 
             npc_size = 12


### PR DESCRIPTION
NPC_1のみが左右に動くようにしました。
NPCを動かすかどうか(true,false)、速度(speed)、距離(max_offset)は、dialogues.jsonでNPCごとに管理する。
（NPCの追加もここから）
移動方向はfield.pyのscreen_x,screen_yの部分で管理。
今回は1人のNPCが左右移動するのみで、今後はNPCごとに異なる動きを実装予定です。